### PR TITLE
Enable kmsdrm support for devices without WMs (such as tv boxes running CoreELEC)

### DIFF
--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -45,7 +45,7 @@ elif [ $TARGET_RID = "linux-arm64" ]; then
 	chmod +x /usr/bin/aarch64-linux-gnu-pkg-config
 	export PKG_CONFIG=aarch64-linux-gnu-pkg-config
 	# cmake cross compiler flags
-	export EXTRA_CMAKE_ARGS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_FLAGS=--target=aarch64-linux-gnu -DCMAKE_CXX_FLAGS=--target=aarch64-linux-gnu"
+	export EXTRA_CMAKE_ARGS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_FLAGS=--target=aarch64-linux-gnu -DCMAKE_CXX_FLAGS=--target=aarch64-linux-gnu -DSDL_KMSDRM=ON -DSDL_KMSDRM_SHARED=ON"
 	# Enable ARM64 packages
 	dpkg --add-architecture arm64
 	apt-get update

--- a/GSE/GSE.cs
+++ b/GSE/GSE.cs
@@ -394,8 +394,11 @@ internal sealed class GSE : IDisposable
 
 				if (windowId == _mainWindow.WindowId)
 				{
-					// Suppress imgui keyboard inputs if the emulator is unpaused with a rom loaded
-					if (eventType is SDL_EventType.SDL_EVENT_KEY_DOWN or SDL_EventType.SDL_EVENT_KEY_UP && _emuManager.EmuAcceptingInputs)
+					// Suppress imgui keyboard inputs if the emulator is unpaused with a rom loaded, so
+					// gameplay keys don't leak into the menus. On kmsdrm the keyboard is a TV remote
+					// used only for the menus, so let it through even while running.
+					if (eventType is SDL_EventType.SDL_EVENT_KEY_DOWN or SDL_EventType.SDL_EVENT_KEY_UP
+					    && _emuManager.EmuAcceptingInputs && !_mainWindow.IsKmsdrmVideo)
 					{
 						continue;
 					}
@@ -464,9 +467,14 @@ internal sealed class GSE : IDisposable
 			var menuBarHeight = 0.0f;
 			var statusBarHeight = 0.0f;
 
-			var hideMenuBar = _config.HideMenuBarOnUnpause && _emuManager.EmuAcceptingInputs && _config.HotkeyBindings.PauseButtonBindings.Count != 0;
+			var hideMenuBar = _config.HideMenuBarOnUnpause && _emuManager.EmuAcceptingInputs && _config.HotkeyBindings.PauseButtonBindings.Count != 0 && !_mainWindow.IsKmsdrmVideo;
 			if (!hideMenuBar)
 			{
+				if (_mainWindow.IsKmsdrmVideo)
+				{
+					ImGuiInternal.FocusMenuBarOnNav();
+				}
+
 				_imGuiMenuBar.RunMenuBar();
 				menuBarHeight = barHeight;
 			}
@@ -485,18 +493,17 @@ internal sealed class GSE : IDisposable
 			ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0);
 			ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0, 0));
 
-			if (ImGui.Begin("GSE", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoBringToFrontOnFocus))
+			if (ImGui.Begin("GSE", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoBringToFrontOnFocus | ImGuiWindowFlags.NoNav | ImGuiWindowFlags.NoFocusOnAppearing))
 			{
 				DrawEmu();
-				ImGui.PopStyleVar(3);
-				_imGuiModals.RunModals();
-			}
-			else
-			{
-				ImGui.PopStyleVar(3);
 			}
 
+			ImGui.PopStyleVar(3);
 			ImGui.End();
+
+			ImGuiInternal.CloseDismissableModalOnEscape();
+
+			_imGuiModals.RunModals();
 
 			if (_config.HideStatusBar)
 			{

--- a/GSE/Gui/ImGuiInternal.cs
+++ b/GSE/Gui/ImGuiInternal.cs
@@ -22,4 +22,16 @@ public static unsafe partial class ImGuiInternal
 	{
 		return igBeginViewportSideBar(name, viewport.NativePtr, dir, size, window_flags);
 	}
+
+	[LibraryImport("cimgui")]
+	[UnmanagedCallConv(CallConvs = [ typeof(CallConvCdecl) ])]
+	private static partial void gseFocusMenuBarOnNav();
+
+	public static void FocusMenuBarOnNav() => gseFocusMenuBarOnNav();
+
+	[LibraryImport("cimgui")]
+	[UnmanagedCallConv(CallConvs = [ typeof(CallConvCdecl) ])]
+	private static partial void gseCloseDismissableModalOnEscape();
+
+	public static void CloseDismissableModalOnEscape() => gseCloseDismissableModalOnEscape();
 }

--- a/GSE/Gui/ImGuiWindow.cs
+++ b/GSE/Gui/ImGuiWindow.cs
@@ -209,6 +209,8 @@ internal sealed class ImGuiWindow : IDisposable
 
 	public readonly uint SdlWindowProperties;
 
+	public bool IsKmsdrmVideo { get; }
+
 	private int _lastWidth, _lastHeight, _lastScale, _lastBars;
 	public bool IsFullscreen { get; private set; }
 
@@ -401,7 +403,8 @@ internal sealed class ImGuiWindow : IDisposable
 
 		fontConfig.OversampleH = fontConfig.OversampleV = 1;
 		fontConfig.PixelSnapH = true;
-		fontConfig.SizePixels = (float)Math.Round(16 * scaleFactor, MidpointRounding.AwayFromZero);
+		var basePixels = IsKmsdrmVideo ? 28 : 16;
+		fontConfig.SizePixels = (float)Math.Round(basePixels * scaleFactor, MidpointRounding.AwayFromZero);
 		fontConfig.FontDataOwnedByAtlas = false;
 
 		io.Fonts.Clear();
@@ -460,6 +463,7 @@ internal sealed class ImGuiWindow : IDisposable
 #endif
 
 			var videoDriver = SDL_GetCurrentVideoDriver();
+			IsKmsdrmVideo = videoDriver == "kmsdrm";
 			_mouseCanUseGlobalState = videoDriver is "windows" or "cocoa" or "x11" or "DIVE" or "VMAN";
 
 			_imGuiContext = ImGui.CreateContext();
@@ -584,8 +588,15 @@ internal sealed class ImGuiWindow : IDisposable
 		SDL_QuitSubSystem(SDL_InitFlags.SDL_INIT_VIDEO | SDL_InitFlags.SDL_INIT_EVENTS);
 	}
 
+	public bool FullscreenLocked { get; private set; }
+
 	public void ToggleFullscreen(Config config)
 	{
+		if (FullscreenLocked)
+		{
+			return;
+		}
+
 		// TODO: how should failure be handled?
 		if (!SDL_SetWindowFullscreen(SdlWindow, !IsFullscreen))
 		{
@@ -738,6 +749,26 @@ internal sealed class ImGuiWindow : IDisposable
 		if (makeVisible)
 		{
 			SDL_ShowWindow(SdlWindow);
+
+#if !GSE_ANDROID
+			if (!FullscreenLocked && IsKmsdrmVideo)
+			{
+				unsafe
+				{
+					var desktop = SDL_GetDesktopDisplayMode(SDL_GetDisplayForWindow(SdlWindow));
+					if (desktop != null)
+					{
+						SDL_SetWindowFullscreenMode(SdlWindow, ref *desktop);
+					}
+				}
+
+				if (SDL_SetWindowFullscreen(SdlWindow, true))
+				{
+					IsFullscreen = true;
+					FullscreenLocked = true;
+				}
+			}
+#endif
 		}
 		else
 		{

--- a/externals/cimgui/CMakeLists.txt
+++ b/externals/cimgui/CMakeLists.txt
@@ -34,6 +34,9 @@ add_subdirectory(cimgui EXCLUDE_FROM_ALL)
 # we don't like that, so restore the prefix
 set_property(TARGET cimgui PROPERTY PREFIX)
 
+# GSE nav helper for appliance (no mouse/keyboard) targets
+target_sources(cimgui PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gse_nav.cpp)
+
 # Copy output to our runtime folders
 add_custom_target(cimgui-gse ALL)
 add_dependencies(cimgui-gse cimgui)

--- a/externals/cimgui/gse_nav.cpp
+++ b/externals/cimgui/gse_nav.cpp
@@ -1,0 +1,54 @@
+#include "imgui.h"
+#include "imgui_internal.h"
+
+#if defined(_WIN32)
+#define GSE_EXPORT extern "C" __declspec(dllexport)
+#else
+#define GSE_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
+
+GSE_EXPORT void gseFocusMenuBarOnNav(void)
+{
+	ImGuiContext& g = *GImGui;
+
+	if (g.NavLayer != ImGuiNavLayer_Main)
+		return;
+	if (g.NavWindow != nullptr && (g.NavWindow->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu)) != 0)
+		return;
+
+	const bool nav_key = ImGui::IsKeyPressed(ImGuiKey_LeftArrow) || ImGui::IsKeyPressed(ImGuiKey_RightArrow)
+		|| ImGui::IsKeyPressed(ImGuiKey_UpArrow) || ImGui::IsKeyPressed(ImGuiKey_DownArrow);
+	if (!nav_key)
+		return;
+
+	ImGuiWindow* menubar = ImGui::FindWindowByName("##MainMenuBar");
+	if (menubar == nullptr || !(menubar->DC.NavLayersActiveMask & (1 << ImGuiNavLayer_Menu)))
+		return;
+
+	ImGui::ClearActiveID();
+	ImGui::FocusWindow(menubar);
+	menubar->NavLastIds[ImGuiNavLayer_Menu] = 0;
+	g.NavLayer = ImGuiNavLayer_Menu;
+	ImGui::NavInitWindow(menubar, true);
+	ImGui::NavRestoreHighlightAfterMove();
+}
+
+GSE_EXPORT void gseCloseDismissableModalOnEscape(void)
+{
+	ImGuiContext& g = *GImGui;
+
+	// imgui closes non-modal popups (e.g. combos) on Escape during NewFrame, before this runs;
+	// if one closed this frame, imgui already consumed the Escape -- don't also close the modal.
+	static int prev_open_popups = 0;
+	const int open_popups = g.OpenPopupStack.Size;
+	const bool imgui_closed_a_popup = open_popups < prev_open_popups;
+	prev_open_popups = open_popups;
+
+	if (open_popups == 0 || imgui_closed_a_popup || g.ActiveId != 0
+		|| !ImGui::IsKeyPressed(ImGuiKey_Escape, false))
+		return;
+
+	ImGuiWindow* top = g.OpenPopupStack.back().Window;
+	if (top && (top->Flags & ImGuiWindowFlags_Modal) && top->HasCloseButton)
+		ImGui::ClosePopupToLevel(open_popups - 1, true);
+}


### PR DESCRIPTION
Enables the SDL kmsdrm video driver so GSE can run on devices without a window manager, such as TV boxes running CoreELEC. Also tweaks ImGui navigation settings (with a small cimgui helper) so IR remotes can be used to navigate the menu.